### PR TITLE
Increase CI jobs timeout

### DIFF
--- a/.github/workflows/nextest.yml
+++ b/.github/workflows/nextest.yml
@@ -113,17 +113,6 @@ jobs:
           chmod +x resolc-universal-apple-darwin
           xattr -d com.apple.quarantine resolc-universal-apple-darwin || true
           sudo mv resolc-universal-apple-darwin /usr/local/bin/resolc
-      - name: Install system deps (Linux)
-        if: contains(matrix.runner_label, 'ubuntu')
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y protobuf-compiler
-
-      - name: Install system deps (macOS)
-        if: contains(matrix.runner_label, 'macos')
-        run: |
-          brew update
-          brew install protobuf
 
       - name: Cache substrate-node binary
         id: cache-substrate
@@ -131,6 +120,18 @@ jobs:
         with:
           path: polkadot-sdk/target/release/substrate-node
           key: substrate-node-${{ matrix.runner_label }}-${{ env.SUBSTRATE_NODE_COMMIT_SHA }}
+
+      - name: Install system deps (Linux)
+        if: steps.cache-substrate.outputs.cache-hit != 'true' && contains(matrix.runner_label, 'ubuntu')
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y protobuf-compiler
+
+      - name: Install system deps (macOS)
+        if: steps.cache-substrate.outputs.cache-hit != 'true' && contains(matrix.runner_label, 'macos')
+        run: |
+          brew update
+          brew install protobuf
 
       - name: Build substrate-node (if not cached)
         if: steps.cache-substrate.outputs.cache-hit != 'true' && !contains(matrix.runner_label, 'windows')

--- a/.github/workflows/nextest.yml
+++ b/.github/workflows/nextest.yml
@@ -121,14 +121,21 @@ jobs:
           path: polkadot-sdk/target/release/substrate-node
           key: substrate-node-${{ matrix.runner_label }}-${{ env.SUBSTRATE_NODE_COMMIT_SHA }}
 
+      - name: Cache eth-rpc binary
+        id: cache-ethrpc
+        uses: actions/cache@v3
+        with:
+          path: ~/.cargo/bin/eth-rpc
+          key: eth-rpc-${{ matrix.runner_label }}-${{ env.ETH_RPC_VERSION }}
+
       - name: Install system deps (Linux)
-        if: steps.cache-substrate.outputs.cache-hit != 'true' && contains(matrix.runner_label, 'ubuntu')
+        if: (steps.cache-substrate.outputs.cache-hit != 'true' || steps.cache-ethrpc.outputs.cache-hit != 'true') && contains(matrix.runner_label, 'ubuntu')
         run: |
           sudo apt-get update
           sudo apt-get install -y protobuf-compiler
 
       - name: Install system deps (macOS)
-        if: steps.cache-substrate.outputs.cache-hit != 'true' && contains(matrix.runner_label, 'macos')
+        if: (steps.cache-substrate.outputs.cache-hit != 'true' || steps.cache-ethrpc.outputs.cache-hit != 'true') && contains(matrix.runner_label, 'macos')
         run: |
           brew update
           brew install protobuf
@@ -145,13 +152,6 @@ jobs:
 
       - name: Add substrate-node to $PATH
         run: echo "${{github.workspace}}/polkadot-sdk/target/release" >> $GITHUB_PATH
-
-      - name: Cache eth-rpc binary
-        id: cache-ethrpc
-        uses: actions/cache@v3
-        with:
-          path: ~/.cargo/bin/eth-rpc
-          key: eth-rpc-${{ matrix.runner_label }}-${{ env.ETH_RPC_VERSION }}
 
       - name: Install eth-rpc proxy (if not cached)
         if: steps.cache-ethrpc.outputs.cache-hit != 'true' && !contains(matrix.runner_label, 'windows')

--- a/.github/workflows/nextest.yml
+++ b/.github/workflows/nextest.yml
@@ -129,13 +129,15 @@ jobs:
           key: eth-rpc-${{ matrix.runner_label }}-${{ env.ETH_RPC_VERSION }}
 
       - name: Install system deps (Linux)
-        if: (steps.cache-substrate.outputs.cache-hit != 'true' || steps.cache-ethrpc.outputs.cache-hit != 'true') && contains(matrix.runner_label, 'ubuntu')
+        if: (steps.cache-substrate.outputs.cache-hit != 'true' || steps.cache-ethrpc.outputs.cache-hit != 'true')
+              && contains(matrix.runner_label, 'ubuntu')
         run: |
           sudo apt-get update
           sudo apt-get install -y protobuf-compiler
 
       - name: Install system deps (macOS)
-        if: (steps.cache-substrate.outputs.cache-hit != 'true' || steps.cache-ethrpc.outputs.cache-hit != 'true') && contains(matrix.runner_label, 'macos')
+        if: (steps.cache-substrate.outputs.cache-hit != 'true' || steps.cache-ethrpc.outputs.cache-hit != 'true')
+              && contains(matrix.runner_label, 'macos')
         run: |
           brew update
           brew install protobuf

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -126,6 +126,7 @@ jobs:
       - rustfmt
       - forge-fmt
       - crate-checks
+      - deny
     timeout-minutes: 60
     steps:
       - name: Decide whether the needed jobs succeeded or failed

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -126,8 +126,7 @@ jobs:
       - rustfmt
       - forge-fmt
       - crate-checks
-      - deny
-    timeout-minutes: 30
+    timeout-minutes: 60
     steps:
       - name: Decide whether the needed jobs succeeded or failed
         uses: re-actors/alls-green@release/v1


### PR DESCRIPTION
Implements: #83 
Current CI jobs timeout is 30 minutes, which is not enough when we need to build substrate-node and eth-rpc.
The timeout has been increased to 60 minutes.